### PR TITLE
Bump the version spec on multipart-post

### DIFF
--- a/pedump.gemspec
+++ b/pedump.gemspec
@@ -102,7 +102,7 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<multipart-post>, ["~> 1.1.4"])
+      s.add_runtime_dependency(%q<multipart-post>, ["~> 1.2"])
       s.add_runtime_dependency(%q<progressbar>, [">= 0"])
       s.add_runtime_dependency(%q<awesome_print>, [">= 0"])
       s.add_runtime_dependency(%q<iostruct>, [">= 0.0.4"])
@@ -112,7 +112,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<jeweler>, [">= 0"])
       s.add_development_dependency(%q<what_methods>, [">= 0"])
     else
-      s.add_dependency(%q<multipart-post>, ["~> 1.1.4"])
+      s.add_dependency(%q<multipart-post>, ["~> 1.2"])
       s.add_dependency(%q<progressbar>, [">= 0"])
       s.add_dependency(%q<awesome_print>, [">= 0"])
       s.add_dependency(%q<iostruct>, [">= 0.0.4"])
@@ -123,7 +123,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<what_methods>, [">= 0"])
     end
   else
-    s.add_dependency(%q<multipart-post>, ["~> 1.1.4"])
+    s.add_dependency(%q<multipart-post>, ["~> 1.2"])
     s.add_dependency(%q<progressbar>, [">= 0"])
     s.add_dependency(%q<awesome_print>, [">= 0"])
     s.add_dependency(%q<iostruct>, [">= 0.0.4"])


### PR DESCRIPTION
This allows bundler to resolve a version of pedump without conflicting with faraday-0.9.0 and higher.